### PR TITLE
Fix issue #3

### DIFF
--- a/conway.c
+++ b/conway.c
@@ -10,6 +10,8 @@
 #define BOARD_SIZE (BOARD_WIDTH * BOARD_HEIGHT)
 
 #define BOARD_SET(x, y) board[((y)*BOARD_WIDTH) + (x)] = 1
+#define BOARD_UNSET(x, y) board[((y)*BOARD_WIDTH) + (x)] = 0
+#define BOARD_TOGGLE(x, y) (board[((y)*BOARD_WIDTH) + (x)]) ? (BOARD_UNSET(x, y)) : (BOARD_SET(x, y))
 
 #define BOARD_GLIDER(x, y)   \
     BOARD_SET(x - 1, y + 0); \
@@ -119,8 +121,10 @@ int main() {
 
 #ifdef CONWAY_PIXEL
 
-void mouse_pressed_cb(int x, int y) {
-    BOARD_SET(x, y);
+void mouse_pressed_cb(int x, int y, PixelMouseButton button) {
+    if (button == PIXEL_MOUSE_BUTTON_LEFT) BOARD_SET(x, y);
+    if (button == PIXEL_MOUSE_BUTTON_RIGHT) BOARD_UNSET(x, y);
+    if (button == PIXEL_MOUSE_BUTTON_MIDDLE) BOARD_TOGGLE(x, y);
     init_sync();
     display();
     pixel_refresh_screen();

--- a/pixel.c
+++ b/pixel.c
@@ -85,11 +85,17 @@ int SDL_main(int argc, char **argv) {
                 }
                 if (event.type == SDL_MOUSEBUTTONDOWN) {
                     if (pixel_init_data.mouse_cb) {
+                        PixelMouseButton button;
                         int x, y;
                         SDL_GetMouseState(&x, &y);
+                        if (event.button.button == SDL_BUTTON_LEFT) button = PIXEL_MOUSE_BUTTON_LEFT;
+                        else if (event.button.button == SDL_BUTTON_RIGHT) button = PIXEL_MOUSE_BUTTON_RIGHT;
+                        else if (event.button.button == SDL_BUTTON_MIDDLE) button = PIXEL_MOUSE_BUTTON_MIDDLE;
+                        else button = PIXEL_MOUSE_BUTTON_UNKNOWN;
                         pixel_init_data.mouse_cb(
                             x / pixel_init_data.pixel_scale,
-                            y / pixel_init_data.pixel_scale);
+                            y / pixel_init_data.pixel_scale,
+                            button);
                     }
                 }
             }

--- a/pixel.h
+++ b/pixel.h
@@ -1,7 +1,14 @@
 #ifndef PIXEL_H
 #define PIXEL_H
 
-typedef void(*PixelMouseCallback)(int,int);
+typedef enum {
+    PIXEL_MOUSE_BUTTON_LEFT,
+    PIXEL_MOUSE_BUTTON_RIGHT,
+    PIXEL_MOUSE_BUTTON_MIDDLE,
+    PIXEL_MOUSE_BUTTON_UNKNOWN
+} PixelMouseButton;
+
+typedef void(*PixelMouseCallback)(int,int, PixelMouseButton);
 
 /* Initialization data for this library. Returned from pixel_init. */
 typedef struct {


### PR DESCRIPTION
The pixel mouse button callback can now distinguish between different
mouse buttons. The left mouse button acts the same as it did before, it
sets the cell that the mouse is hovering over. The right mouse button
now will unset the cell that the mouse is hovering over. And the middle
mouse button will toggle the cell that the mouse is over.

fix #3